### PR TITLE
Cucumber example fixing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/examples/cucumber/features/support/world.js
+++ b/examples/cucumber/features/support/world.js
@@ -15,12 +15,12 @@ var World = function World(callback) {
             },
             child: {
                 port: 8081,
-                spooky_lib: './node_modules',
+                spooky_lib: './',
                 script: './lib/bootstrap.js'
             }
         }, onCreated);
     } catch (e) {
-        console.dir(e)
+        console.dir(e);
         console.trace('Spooky.listen failed');
     }
 
@@ -66,10 +66,8 @@ var World = function World(callback) {
         }
     });
 
-    function onCreated(err, error, response) {
-        if (err) {
-            throw err;
-        } else if (error) {
+    function onCreated(error, response) {
+        if (error) {
             console.dir(error);
             throw new Error('Failed to initialize context.spooky: ' +
                 error.code + ' - '  + error.message);

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "devDependencies": {
         "mocha": "1.3.x",
         "expect.js": "0.1.x",
+        "cucumber": "*",
         "http-server": "0.5.x"
     },
 


### PR DESCRIPTION
Changed the spooky_lib location for world.js and removed the extra
error parameter that was breaking onCreated.

There may have been a reason for the `(err, error, response)` that I don't know about but it was blocking execution so I took it out. 

I also added cucumber to the devDependencies. It's not strictly a dev dependency but it could be a bit confusing to get the example running first time without it.
