### PR TITLE
Allow spooky to be installed with -g

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+*.swp

--- a/README.md
+++ b/README.md
@@ -13,19 +13,16 @@ Drive [CasperJS](http://casperjs.org/) from Node.js.
 SpookyJS is available from npm.
 
 ``` shell
-$ npm install spooky
+$ npm install -g spooky
 ```
 
 ## Usage
 
 ``` javascript
-var Spooky = require('../lib/spooky');
+var Spooky = require('spooky');
 
 var spooky = new Spooky({
-        child: {
-            script: './lib/bootstrap.js',
-            spooky_lib: './node_modules'
-        },
+        // Configuraiton options for casper
         casper: {
             logLevel: 'debug',
             verbose: true

--- a/lib/spooky.js
+++ b/lib/spooky.js
@@ -26,8 +26,8 @@ var defaults = {
     child: {
         command: 'casperjs',
         port: 8081,
-        script: './node_modules/spooky/lib/bootstrap.js',
-        spooky_lib: './node_modules/spooky/',
+        script: __dirname + '/bootstrap.js',
+        spooky_lib: __dirname + '/../',
         transport: 'stdio',
         bufferSize: 16 * 1024 // 16KB
     },


### PR DESCRIPTION
This means the user does not have to worry about spooky install paths
nor do they have to install it in their own codebase. Spooky path issues
are an impressively common source of error (Github issue 14 / 15)
