### PR TITLE
make casper paths relative to spooky and not cwd

### DIFF
--- a/lib/spooky.js
+++ b/lib/spooky.js
@@ -1,5 +1,6 @@
 var spawn = require('child_process').spawn;
 var util = require('util');
+var path = require('path');
 
 var _ = require('underscore');
 
@@ -16,6 +17,7 @@ var BufferedStream = require('./spooky/buffered-stream');
 var FilteredStream = require('./spooky/filtered-stream');
 
 var tinyjsonrpc = require('tiny-jsonrpc');
+var spookyDir = path.resolve(path.join(path.dirname(__filename), '..'));
 
 var defaults = {
     transport: {
@@ -26,8 +28,8 @@ var defaults = {
     child: {
         command: 'casperjs',
         port: 8081,
-        script: './node_modules/spooky/lib/bootstrap.js',
-        spooky_lib: './node_modules/spooky/',
+        script: path.join(spookyDir, 'lib/bootstrap.js'),
+        spooky_lib: spookyDir + '/',
         transport: 'stdio',
         bufferSize: 16 * 1024 // 16KB
     },


### PR DESCRIPTION
the paths for the casper `script` and `spooky_lib` options were relative
to the current working directory, however they should be relative to
spooky's installation directory. this comes up when spooky is installed
somewhere other than `./node_modules/spooky`.
