### PR TITLE
Fix prototype inheritance with CoffeeScript's __extends

### DIFF
--- a/lib/spooky.js
+++ b/lib/spooky.js
@@ -35,6 +35,8 @@ var defaults = {
     }
 };
 
+var __hasProp = {}.hasOwnProperty,__extends = function(child, parent) { for (var key in parent) { if (__hasProp.call(parent, key)) child[key] = parent[key]; } function ctor() { this.constructor = child; } ctor.prototype = parent.prototype; child.prototype = new ctor(); child.__super__ = parent.prototype; return child; };
+
 function isJsonRpcRequest(s) {
     try {
         s = JSON.parse(s);
@@ -126,8 +128,9 @@ function Spooky(options, callback) {
     }).bind(this));
 }
 
-Spooky.prototype = new EventEmitter();
-Spooky.prototype.constructor = Spooky;
+__extends(Spooky, EventEmitter);
+// Spooky.prototype = new EventEmitter();
+// Spooky.prototype.constructor = Spooky;
 
 Spooky._instances = {};
 Spooky._nextInstanceId = 0;


### PR DESCRIPTION
The prototype chain:

```
// Spooky.prototype = new EventEmitter();
// Spooky.prototype.constructor = Spooky;
```

is WRONG.
Change to CS's __extends solve the problem.

```
__extends(Spooky, EventEmitter);
```
