### PR TITLE
Allow casper restart in stdio server

### DIFF
--- a/lib/bootstrap/casper.js
+++ b/lib/bootstrap/casper.js
@@ -93,6 +93,12 @@ function getCreateFn(server) {
         server._instance = instance = casper.create(options);
         instance.emit = function () {
             var args = Array.prototype.slice.apply(arguments);
+            if (args[0] === 'starting') {
+                server.stop && server.stop();
+            } else if (args[0] === 'run.complete') {
+                server.start && server.start();
+            }
+
             try {
                 emit.apply(this, arguments);
             } catch (e) {

--- a/lib/bootstrap/stdio-server.js
+++ b/lib/bootstrap/stdio-server.js
@@ -40,8 +40,17 @@ var StreamServer = require(options.spooky_lib +
 var server = new StreamServer();
 server.listen(stream);
 
-// stdin.readLine blocks until input is available, so we must wait until setup
-// is complete before checking for input. Otherwise, the module will never
-// finish executing.
-setTimeout(loop, 0);
+var loopTimer;
+server.start = function() {
+  // stdin.readLine blocks until input is available, so we must wait until setup
+  // is complete before checking for input. Otherwise, the module will never
+  // finish executing.
+  loopTimer = setTimeout(loop, 0);
+};
+server.stop = function() {
+  clearTimeout(loopTimer);
+};
+
+server.start();
+
 module.exports = server;

--- a/tests/test/stdio.js
+++ b/tests/test/stdio.js
@@ -69,4 +69,80 @@ describe('Spooky provides a stdio transport', function () {
             });
         });
     });
+
+    it('allows restarts after completion', function (done) {
+        var out = [];
+
+        function onConsole(line) {
+            if (line === 'Fourth') {
+                expect(out).to.contain('First');
+                expect(out).to.contain('Second');
+                expect(out).to.contain('Third');
+                context.spooky.removeListener('console', onConsole);
+                done();
+                return;
+            }
+
+            out.push(line);
+        }
+        context.spooky.on('console', onConsole);
+
+        context.spooky.start();
+        context.spooky.then(function () {
+            this.echo('First');
+        });
+        context.spooky.then(function () {
+            this.echo('Second');
+        });
+        context.spooky.run(function() {
+            this.emit('test.done');
+        });
+
+        context.spooky.on('test.done', function() {
+            context.spooky.start();
+            context.spooky.then(function () {
+                this.echo('Third');
+            });
+            context.spooky.then(function () {
+                this.echo('Fourth');
+            });
+            context.spooky.run();
+        });
+    });
+
+    it('allows restarts queued before completion', function (done) {
+        var out = [];
+
+        function onConsole(line) {
+            if (line === 'Fourth') {
+                expect(out).to.contain('First');
+                expect(out).to.contain('Second');
+                expect(out).to.contain('Third');
+                context.spooky.removeListener('console', onConsole);
+                done();
+                return;
+            }
+
+            out.push(line);
+        }
+        context.spooky.on('console', onConsole);
+
+        context.spooky.start();
+        context.spooky.then(function () {
+            this.echo('First');
+        });
+        context.spooky.then(function () {
+            this.echo('Second');
+        });
+        context.spooky.run(function() {});
+
+        context.spooky.start();
+        context.spooky.then(function () {
+            this.echo('Third');
+        });
+        context.spooky.then(function () {
+            this.echo('Fourth');
+        });
+        context.spooky.run();
+    });
 });


### PR DESCRIPTION
Always run the server event loop while casper is not running. This hacks
around the blocking behavior of the phantom readLine implementation.
