### PR TITLE
Defer child exit error

### DIFF
--- a/lib/spooky.js
+++ b/lib/spooky.js
@@ -179,13 +179,21 @@ Spooky.prototype._spawnChild = function () {
                 code: code,
                 signal: signal
             };
-            this.emit('error', e);
+
+            var exitHandler = (function() {
+                if (!this.destroyed) {
+                    this.emit('error', e);
+                }
+            }).bind(this);
+
+            setTimeout(exitHandler, 10);
         }
     }).bind(this));
     return child;
 };
 
 Spooky.prototype.destroy = function () {
+    this.destroyed = true;
     this._child.kill();
     delete Spooky._instances[this.options.child.port];
 };


### PR DESCRIPTION
Allows pending messages to be processed. Additionally allows client to
cleanup to perform their own error handling via the destroy method.
