### PR TITLE
Casper module not found issue fixed

### DIFF
--- a/lib/bootstrap/casper.js
+++ b/lib/bootstrap/casper.js
@@ -1,13 +1,12 @@
-if (phantom.casperVersion.major >= 1 &&
-    (phantom.casperVersion.minor > 0 || phantom.casperVersion.patch > 2)
-) {
-    require = patchRequire(require);
-}
-
 var options = phantom.casperArgs.options;
 var createFunction =
     require(options.spooky_lib + 'lib/bootstrap/create-function');
-var casper = require('casper');
+try {
+    var casper = require('casper');
+} catch (e) {
+    require = patchRequire(require);    
+    var casper = require('casper');
+}
 var emit = require(options.spooky_lib + 'lib/bootstrap/emit').emit;
 var instance;
 


### PR DESCRIPTION
OS: OSX 10.8.5
Phantom: 1.9.2
Casper: 1.1 beta and 1.04 stable

I've spent some time figuring out why the hello.js example wasn't working even after setting up properly all the paths and env variables so I've dig deeper in the code and I've found the error was throw because the patchRequire method wasn't call as this last one it's supposed to be called only for some version of casper.

To prevent this error I've thought to use a try-catch instead of checking on versions.
