### PR TITLE
Bad Regex - Spooky scripts always fail on Windows

### DIFF
--- a/lib/bootstrap/create-function.js
+++ b/lib/bootstrap/create-function.js
@@ -37,7 +37,7 @@ var createFunction = (function () {
 
         // parse the function source into name, arguments, and body
         // currently, names must by alphanumeric.
-        parsed = src.replace(/\n/g, newlineToken).
+        parsed = src.replace(/\r?\n/g, newlineToken).
             match(/^function\s+([a-zA-Z_]\w*)?\s*\(([^)]*)\)\s*\{(.*)\}$/);
         if (!parsed) {
             throw 'Cannot parse function: ' +


### PR DESCRIPTION
How did you guys got anything done without this change? not even the Quickstart script in README.md works without this change on windows. 

This is a hot fix, a proper fix would be to use a proper parsing library for parsing such as Uglifyjs

Using latest Phantom/Casper/Node
Casperjs 1.1.0-beta3
Phantomjs 1.9.7
Node 0.10.29
