### PR TITLE
Add support for casper 1.0 style of arguments.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,5 @@ before_script:
 env:
   matrix:
     - CASPER_VERSION=1.0.0-RC4
-    - CASPER_VERSION=1.0.0
     - CASPER_VERSION=1.0.4
     - CASPER_VERSION=master

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,16 @@ node_js:
 before_install:
   - git clone git://github.com/n1k0/casperjs.git ~/casperjs
   - cd ~/casperjs
+  - git checkout $CASPER_VERSION
   - export PATH=$PATH:`pwd`/bin
   - cd -
 before_script:
   - phantomjs --version
   - casperjs --version
+
+env:
+  matrix:
+    - CASPER_VERSION=1.0.0-RC4
+    - CASPER_VERSION=1.0.0
+    - CASPER_VERSION=1.0.4
+    - CASPER_VERSION=master

--- a/lib/bootstrap/casper.js
+++ b/lib/bootstrap/casper.js
@@ -20,7 +20,7 @@ var methodsToProvide = {
     start: ['url', function then () {}],
     then: [function fn () {}],
     thenClick: ['selector', function fn () {}],
-    thenEvaluate: [function fn () {}, 'replacements'],
+    thenEvaluate: [function fn () {}, 'replacements...'],
     thenOpen: ['location', 'options'],
     thenOpenAndEvaluate: ['location', function fn () {}, 'replacements'],
     userAgent: ['agent'],
@@ -56,12 +56,11 @@ var methodsToProvide = {
     withFrame: ['frameInfo', function then () {}],
     withPopup: ['popupInfo', function then () {}]
 };
-methodsToProvide.thenEvaluate.allowMore = true;
 
 function callMethod(method, spec) {
     var args = Array.prototype.slice.call(arguments, 2);
 
-    if (args.length > spec.length && !spec.allowMore) {
+    if (args.length > spec.length && spec.indexOf('replacements...') === -1) {
         throw [
             'Expected maximum of', spec.length,
             'arguments, but got', args.length

--- a/lib/bootstrap/casper.js
+++ b/lib/bootstrap/casper.js
@@ -56,11 +56,12 @@ var methodsToProvide = {
     withFrame: ['frameInfo', function then () {}],
     withPopup: ['popupInfo', function then () {}]
 };
+methodsToProvide.thenEvaluate.allowMore = true;
 
 function callMethod(method, spec) {
     var args = Array.prototype.slice.call(arguments, 2);
 
-    if (args.length > spec.length) {
+    if (args.length > spec.length && !spec.allowMore) {
         throw [
             'Expected maximum of', spec.length,
             'arguments, but got', args.length

--- a/lib/bootstrap/casper.js
+++ b/lib/bootstrap/casper.js
@@ -1,5 +1,7 @@
-if (phantom.casperVersion.major >= 1 &&
-    (phantom.casperVersion.minor > 0 || phantom.casperVersion.patch > 2)
+var casperVersion = phantom.casperVersion;
+
+if (casperVersion.major >= 1 &&
+    (casperVersion.minor > 0 || casperVersion.patch > 2)
 ) {
     require = patchRequire(require);
 }
@@ -56,6 +58,12 @@ var methodsToProvide = {
     withFrame: ['frameInfo', function then () {}],
     withPopup: ['popupInfo', function then () {}]
 };
+
+if (casperVersion.major < 1 ||
+    (casperVersion.major == 1 && casperVersion.minor == 0 &&
+     casperVersion.patch == 0 && casperVersion.ident.substr(0, 2) == 'RC' && parseInt(casperVersion.ident.substr(2), 10) < 5)) {
+    methodsToProvide.thenEvaluate[1] == 'replacements'
+}
 
 function callMethod(method, spec) {
     var args = Array.prototype.slice.call(arguments, 2);

--- a/tests/test/then.js
+++ b/tests/test/then.js
@@ -174,6 +174,37 @@ describe("Spooky provides Casper's then* functions", function () {
                 context.spooky.run();
             });
 
+        it('accepts an optional arguments',
+            function (done) {
+                context.spooky.start(FIXTURE_URL + '/1.html');
+
+                context.spooky.thenEvaluate(function (foo, bar) {
+                    window.__foo = foo;
+                    window.__bar = bar;
+                }, 'foo', 'bar');
+
+                context.spooky.waitFor(function () {
+                    return this.evaluate(function () {
+                        return (window.__foo === 'foo' && window.__bar === 'bar');
+                    });
+                });
+
+                context.spooky.then(function () {
+                    this.echo('done');
+                });
+
+                function onConsole(line) {
+                    if (line === 'done') {
+                        context.spooky.removeListener('console', onConsole);
+                        done();
+                        return;
+                    }
+                }
+                context.spooky.on('console', onConsole);
+
+                context.spooky.run();
+            });
+
         // TODO: Figure out how to test the optional settings object
     });
 


### PR DESCRIPTION
See #68.

This a WIP to support casper 1.0 arguments style.

I added support for multiple arguments to the `thenEvaluate` method.

The `allowMore` is quite hacky and need some work. Any thought?
