### PR TITLE
fixed example script such that PhantomJS does not fail on an SSL error

### DIFF
--- a/examples/hello.js
+++ b/examples/hello.js
@@ -6,7 +6,9 @@ try {
 
 var spooky = new Spooky({
         child: {
-            transport: 'http'
+            transport: 'http',
+            "ssl-protocol": "any",
+            "ignore-ssl-errors" : true
         },
         casper: {
             logLevel: 'debug',


### PR DESCRIPTION
This script was not working for me on clean `git clone` and `npm install`. PhantomJS was getting hung on Wikipedia's use of SSL.
