### PR TITLE
Indicate the subject method when throwing and argument count mismatch error

### DIFF
--- a/lib/bootstrap/casper.js
+++ b/lib/bootstrap/casper.js
@@ -62,6 +62,7 @@ function callMethod(method, spec) {
 
     if (args.length > spec.length) {
         throw [
+            method+'():',
             'Expected maximum of', spec.length,
             'arguments, but got', args.length
         ].join(' ');


### PR DESCRIPTION
This will make this error actually useful, or at the very least slightly useful as opposed to now where it just causes confusion by not indicating the source of the problem.
